### PR TITLE
Debug input container visibility on large mobile screens

### DIFF
--- a/src/assets/styles/styles.css
+++ b/src/assets/styles/styles.css
@@ -1614,12 +1614,19 @@ body.landing-page {
 @media (max-width: 768px) {
   .input-container {
     padding: 12px 16px;
+    max-height: 120px; /* Universal max-height for mobile */
+    flex-shrink: 0; /* Prevent shrinking */
+    position: relative;
+    z-index: 10; /* Ensure visibility */
+    background: var(--bg-secondary);
   }
 
   .input-wrapper {
     padding: 12px 12px 48px 12px;
     border-radius: 20px;
     min-height: 70px;
+    max-height: 100px; /* Limit wrapper height */
+    position: relative;
   }
   
   .button-group {
@@ -1637,7 +1644,7 @@ body.landing-page {
   
   #user-input {
     font-size: clamp(14px, 4vw, 16px);
-    max-height: 100px;
+    max-height: 80px; /* Reduced max-height for better control */
   }
 }
 
@@ -1730,6 +1737,8 @@ body.landing-page {
     flex-direction: column;
     height: 100vh;
     height: 100dvh; /* Use dynamic viewport height for mobile */
+    max-height: 100vh; /* Prevent overflow on very tall screens */
+    max-height: 100dvh;
     overflow: hidden;
   }
   /* Sidebar styles */
@@ -1794,8 +1803,11 @@ body.landing-page {
     width: 100%;
     height: 100vh;
     height: 100dvh; /* Use dynamic viewport height for mobile */
+    max-height: 100vh; /* Critical: Prevent container from exceeding viewport */
+    max-height: 100dvh;
     display: flex;
     flex-direction: column;
+    overflow: hidden; /* Prevent scrolling of entire container */
   }
 
   /* Chat Header Responsive */
@@ -1813,6 +1825,8 @@ body.landing-page {
     flex: 1;
     overflow-y: auto;
     min-height: 0; /* Important: allows flex item to shrink below content size */
+    max-height: calc(100vh - 120px); /* Reserve space for header + input container */
+    max-height: calc(100dvh - 120px);
   }
 
   /* Message Responsive Adjustments */
@@ -1946,12 +1960,16 @@ body.landing-page {
   .chat-container {
     height: 100vh;
     height: 100dvh; /* Use dynamic viewport height */
+    max-height: 100vh; /* Critical: Prevent exceeding viewport */
+    max-height: 100dvh;
     min-height: 800px; /* Ensure minimum height for tall screens */
   }
   
   #chat-box {
     flex: 1;
     min-height: 0; /* Allow flex shrinking */
+    max-height: calc(100vh - 140px); /* Reserve 140px for header + input */
+    max-height: calc(100dvh - 140px);
     overflow-y: auto;
   }
   
@@ -1961,11 +1979,12 @@ body.landing-page {
     z-index: 10; /* Ensure it stays on top */
     background: var(--bg-secondary);
     border-top: 1px solid var(--border-primary); /* Add visual separation */
+    max-height: 120px; /* Limit input container height */
   }
   
   .input-wrapper {
     min-height: 70px;
-    max-height: none; /* Remove height restrictions on tall screens */
+    max-height: 100px; /* Limit wrapper height on tall screens */
   }
 }
 
@@ -1973,14 +1992,23 @@ body.landing-page {
 @media (max-width: 768px) and (min-height: 900px) {
   .chat-container {
     min-height: 900px;
+    max-height: 100vh; /* Prevent exceeding viewport */
+    max-height: 100dvh;
+  }
+  
+  #chat-box {
+    max-height: calc(100vh - 160px); /* More space reserved for input */
+    max-height: calc(100dvh - 160px);
   }
   
   .input-container {
     padding: 16px 20px; /* Increase padding for better visibility */
+    max-height: 140px; /* Limit container height */
   }
   
   .input-wrapper {
     min-height: 80px; /* Increase minimum height */
+    max-height: 120px; /* Limit wrapper height */
   }
 }
 
@@ -1989,13 +2017,15 @@ body.landing-page {
   .chat-container {
     height: 100vh;
     height: 100dvh;
-    max-height: 100vh;
+    max-height: 100vh; /* Critical in landscape */
     max-height: 100dvh;
   }
   
   #chat-box {
     flex: 1;
     min-height: 0;
+    max-height: calc(100vh - 100px); /* Reserve space for header + input */
+    max-height: calc(100dvh - 100px);
     overflow-y: auto;
     padding: 12px 16px; /* Reduce padding in landscape */
   }
@@ -2004,11 +2034,17 @@ body.landing-page {
     flex-shrink: 0;
     position: relative;
     padding: 8px 16px; /* Reduce padding in landscape */
+    max-height: 80px; /* Limit height in landscape */
   }
   
   .input-wrapper {
     min-height: 60px; /* Reduce height in landscape */
+    max-height: 70px; /* Limit height in landscape */
     padding: 10px 10px 40px 10px;
+  }
+  
+  #user-input {
+    max-height: 40px; /* Smaller input in landscape */
   }
   
   .button-group {
@@ -2031,6 +2067,8 @@ body.landing-page {
     flex-direction: column;
     height: 100vh;
     height: 100dvh;
+    max-height: 100vh; /* Critical: Never exceed viewport */
+    max-height: 100dvh;
     min-height: 100vh;
     min-height: 100dvh;
   }
@@ -2038,6 +2076,8 @@ body.landing-page {
   #chat-box {
     flex: 1 1 auto; /* Allow growing and shrinking */
     min-height: 0; /* Critical for flex child to shrink */
+    max-height: calc(100vh - 180px); /* Reserve 180px for header + input */
+    max-height: calc(100dvh - 180px);
     overflow-y: auto;
     padding: 16px 12px;
   }
@@ -2049,15 +2089,16 @@ body.landing-page {
     background: var(--bg-secondary);
     border-top: 1px solid var(--border-primary);
     z-index: 100; /* Ensure it's always on top */
+    max-height: 160px; /* Limit input container height */
   }
   
   .input-wrapper {
     min-height: 80px;
-    max-height: 200px; /* Allow more height on tall screens */
+    max-height: 140px; /* Controlled height on very tall screens */
   }
   
   #user-input {
-    max-height: 150px; /* Allow more text input on tall screens */
+    max-height: 100px; /* Reasonable text input height */
   }
 }
 
@@ -2067,8 +2108,41 @@ body.landing-page {
     #app-container,
     .chat-container {
       height: 100vh !important;
+      max-height: 100vh !important;
       min-height: 100vh !important;
     }
+  }
+}
+
+/* Universal mobile max-height safety net */
+@media (max-width: 768px) {
+  /* Ensure no mobile screen can push input off-screen */
+  .chat-container {
+    max-height: 100vh;
+    max-height: 100dvh;
+    overflow: hidden;
+  }
+  
+  #chat-box {
+    max-height: calc(100vh - 140px); /* Always reserve 140px for header + input */
+    max-height: calc(100dvh - 140px);
+    overflow-y: auto;
+  }
+  
+  .input-container {
+    max-height: 120px; /* Never exceed 120px */
+    min-height: 70px; /* But never go below 70px */
+    flex-shrink: 0;
+    position: relative;
+    z-index: 100;
+  }
+  
+  .input-wrapper {
+    max-height: 100px; /* Wrapper max-height */
+  }
+  
+  #user-input {
+    max-height: 80px; /* Input max-height */
   }
 }
 
@@ -2077,6 +2151,8 @@ body.landing-page {
   .chat-container {
     height: 100vh;
     height: 100dvh;
+    max-height: 100vh; /* Critical: Never exceed viewport */
+    max-height: 100dvh;
     display: flex;
     flex-direction: column;
     overflow: hidden;
@@ -2085,6 +2161,8 @@ body.landing-page {
   #chat-box {
     flex: 1;
     min-height: 0;
+    max-height: calc(100vh - 150px); /* Reserve 150px for header + input */
+    max-height: calc(100dvh - 150px);
     overflow-y: auto;
     padding: 16px 12px;
     /* Ensure there's space for input container */
@@ -2097,6 +2175,7 @@ body.landing-page {
     background: var(--bg-secondary);
     padding: 12px 16px;
     border-top: 1px solid var(--border-primary);
+    max-height: 130px; /* Limit input container height */
     /* Force visibility */
     display: block !important;
     visibility: visible !important;
@@ -2105,8 +2184,13 @@ body.landing-page {
   
   .input-wrapper {
     min-height: 70px;
+    max-height: 110px; /* Limit wrapper height */
     display: flex !important;
     flex-direction: column;
+  }
+  
+  #user-input {
+    max-height: 80px; /* Limit text input height */
   }
 }
 


### PR DESCRIPTION
Ensure input container visibility on tall mobile screens (800px+ height) by addressing `100vh` conflicts, flex layout issues, and adding specific media queries.

Previously, mobile screens with heights of 800 pixels or more caused the input container to disappear. This was due to `100vh` not accounting for dynamic viewport changes, incorrect flexbox behavior, and a lack of specific CSS rules for these taller devices, including iOS Safari quirks and landscape orientations.

---
<a href="https://cursor.com/background-agent?bcId=bc-349955f1-b137-48b6-b382-ba0943c14704"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-349955f1-b137-48b6-b382-ba0943c14704"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

