### PR TITLE
Set max-height for mobile input container

### DIFF
--- a/src/assets/styles/styles.css
+++ b/src/assets/styles/styles.css
@@ -1599,12 +1599,14 @@ body.landing-page {
 @media (max-width: 768px) {
   .input-container {
     padding: 12px 16px;
+    max-height: 200px; /* Add max-height to prevent input container from becoming too tall on mobile */
   }
 
   .input-wrapper {
     padding: 12px 12px 48px 12px;
     border-radius: 20px;
     min-height: 70px;
+    max-height: 180px; /* Add max-height for the wrapper as well */
   }
   
   .button-group {
@@ -1839,11 +1841,13 @@ body.landing-page {
   /* Input Container Responsive */
   .input-container {
     padding: 12px 16px;
+    max-height: 200px; /* Add max-height to prevent input container from becoming too tall on mobile */
   }
 
   .input-wrapper {
     padding: 12px 12px 48px 12px;
     min-height: 70px;
+    max-height: 180px; /* Add max-height for the wrapper as well */
   }
 
   #user-input {


### PR DESCRIPTION
Add `max-height` to mobile input container styles to fix display issues on high-height mobile viewports.

On mobile devices with high viewport heights, the input container could expand excessively, causing display issues. Adding `max-height` ensures the input area remains accessible and properly displayed without taking up too much screen real estate.

---
<a href="https://cursor.com/background-agent?bcId=bc-17b0a181-7372-4668-943e-0a3f0cdba0ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-17b0a181-7372-4668-943e-0a3f0cdba0ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

